### PR TITLE
fix: path / dates parameters

### DIFF
--- a/KPI.py
+++ b/KPI.py
@@ -4,11 +4,11 @@ import logging
 import argparse
 import json
 
-customer_file = 'customer_data.csv'
-purchase_file = 'purchase_data.csv'
-sales_file = 'sales_data.csv'
-start_date_str = '2024-01-01'
-end_date_str = '2024-12-31'
+customer_file = 'data/customer_data.csv'
+purchase_file = 'data/purchase_data.csv'
+sales_file = 'data/sales_data.csv'
+start_date_str = '2025-01-01'
+end_date_str = '2025-12-31'
 
 start_date = pd.to_datetime(start_date_str).date() if start_date_str else None
 end_date = pd.to_datetime(end_date_str).date() if end_date_str else None


### PR DESCRIPTION
This pull request updates file paths and default date ranges in the `KPI.py` script to reflect changes in data organization and analysis periods.

Configuration updates:

* Updated file paths for `customer_file`, `purchase_file`, and `sales_file` to include a `data/` directory, aligning with a new data organization structure. (`[KPI.pyL7-R11](diffhunk://#diff-42fb314774b35dc0252c6b3ff386f1482d731b160444ba7a605f3b5701b6b37aL7-R11)`)
* Changed the default `start_date_str` and `end_date_str` to `2025-01-01` and `2025-12-31`, respectively, to match the updated analysis period. (`[KPI.pyL7-R11](diffhunk://#diff-42fb314774b35dc0252c6b3ff386f1482d731b160444ba7a605f3b5701b6b37aL7-R11)`)